### PR TITLE
filtering pull requests based on the base (target) branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ vendor/bin/changelog-linker dump-merges --in-categories --in-packages
 - [#860] Add test case for #855, Thanks to @OndraM
 ```
 
+Do you want to dump only such pull requests that were merged into a particular branch? Just use `base-branch` option:
+
+```
+vendor/bin/changelog-linker dump-merges --base-branch=7.3
+```
+This is very handy when you support multiple versions of your project.
+
 ### Github API Overload?
 
 In case you cross the API rate limit and get denied, create [new Github Token](https://github.com/settings/tokens) and run it via `GITHUB_TOKEN` ENV variable.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "symplify/changelog-linker",
-    "description": "Generates beautiful CHANGELOG.md with links to PRs, versions and users grouped in Added/Changed/Fixed/Removed categories.",
+    "name": "shopsys/changelog-linker",
+    "description": "[FORK] Generates beautiful CHANGELOG.md with links to PRs, versions and users grouped in Added/Changed/Fixed/Removed categories.",
     "license": "MIT",
     "bin": [
         "bin/changelog-linker"

--- a/src/Analyzer/IdsAnalyzer.php
+++ b/src/Analyzer/IdsAnalyzer.php
@@ -17,13 +17,22 @@ final class IdsAnalyzer
 
     public function getHighestIdInChangelog(string $content): ?int
     {
+        $ids = $this->getAllIdsInChangelog($content);
+
+        return (int) max($ids);
+    }
+
+    /**
+     * @param string $content
+     * @return array|null
+     */
+    public function getAllIdsInChangelog(string $content): ?array
+    {
         $matches = Strings::matchAll($content, self::PR_REFERENCE_IN_LIST);
         if (! $matches) {
             return null;
         }
 
-        $ids = array_column($matches, 'id');
-
-        return (int) max($ids);
+        return array_column($matches, 'id');
     }
 }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -33,4 +33,9 @@ final class Option
      * @var string
      */
     public const SINCE_ID = 'since-id';
+
+    /**
+     * @var string
+     */
+    public const BASE_BRANCH = 'base-branch';
 }

--- a/src/Console/Command/DumpMergesCommand.php
+++ b/src/Console/Command/DumpMergesCommand.php
@@ -131,6 +131,13 @@ final class DumpMergesCommand extends Command
             InputOption::VALUE_REQUIRED,
             'Include pull-request with provided ID and higher. The ID is detected in CHANGELOG.md otherwise.'
         );
+
+        $this->addOption(
+            Option::BASE_BRANCH,
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Base branch towards which the pull requests are targeted'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -140,7 +147,7 @@ final class DumpMergesCommand extends Command
         $this->changelogFileSystemGuard->ensurePlaceholderIsPresent($content, self::CHANGELOG_PLACEHOLDER_TO_WRITE);
 
         $sinceId = $this->getSinceIdFromInputAndContent($input, $content) ?: 1;
-        $pullRequests = $this->githubApi->getMergedPullRequestsSinceId($sinceId);
+        $pullRequests = $this->githubApi->getMergedPullRequestsSinceId($sinceId, $input->getOption(Option::BASE_BRANCH));
         if (count($pullRequests) === 0) {
             $this->symfonyStyle->note(
                 sprintf('There are no new pull requests to be added since ID "%d".', $sinceId)

--- a/src/Console/Command/DumpMergesCommand.php
+++ b/src/Console/Command/DumpMergesCommand.php
@@ -194,6 +194,31 @@ final class DumpMergesCommand extends Command
             return (int) $sinceId;
         }
 
+        $baseBranch = $input->getOption(Option::BASE_BRANCH);
+
+        if ($baseBranch !== null) {
+            return $this->findHighestIdMergedInBranch($content, $baseBranch);
+        }
+
         return $this->idsAnalyzer->getHighestIdInChangelog($content);
+    }
+
+    /**
+     * @param string $content
+     * @param string $branch
+     * @return int|null
+     */
+    private function findHighestIdMergedInBranch(string $content, string $branch): ?int
+    {
+        $allIdsInChangelog = $this->idsAnalyzer->getAllIdsInChangelog($content);
+        rsort($allIdsInChangelog);
+
+        foreach ($allIdsInChangelog as $id) {
+            if ($this->githubApi->isPullRequestMergedToBaseBranch((int) $id, $branch)) {
+                return (int) $id;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Console/Command/DumpMergesCommand.php
+++ b/src/Console/Command/DumpMergesCommand.php
@@ -214,8 +214,9 @@ final class DumpMergesCommand extends Command
         rsort($allIdsInChangelog);
 
         foreach ($allIdsInChangelog as $id) {
-            if ($this->githubApi->isPullRequestMergedToBaseBranch((int) $id, $branch)) {
-                return (int) $id;
+            $idInt = (int) $id;
+            if ($this->githubApi->isPullRequestMergedToBaseBranch($idInt, $branch)) {
+                return $idInt;
             }
         }
 

--- a/src/Github/GithubApi.php
+++ b/src/Github/GithubApi.php
@@ -65,9 +65,9 @@ final class GithubApi
     /**
      * @return mixed[]
      */
-    public function getMergedPullRequestsSinceId(int $id): array
+    public function getMergedPullRequestsSinceId(int $id, ?string $baseBranch = null): array
     {
-        $pullRequests = $this->getPullRequestsSinceId($id);
+        $pullRequests = $this->getPullRequestsSinceId($id, $baseBranch);
 
         $mergedPullRequests = $this->filterMergedPullRequests($pullRequests);
 
@@ -88,13 +88,16 @@ final class GithubApi
     /**
      * @return mixed[]
      */
-    private function getPullRequestsSinceId(int $id): array
+    private function getPullRequestsSinceId(int $id, ?string $baseBranch = null): array
     {
         $maxPage = 10; // max. 1000 merge requests to dump
 
         $pullRequests = [];
         for ($i = 1; $i <= $maxPage; ++$i) {
             $url = sprintf(self::URL_CLOSED_PULL_REQUESTS, $this->repositoryName) . '&page=' . $i;
+            if ($baseBranch !== null) {
+                $url .= '&base=' . $baseBranch;
+            }
             $response = $this->getResponseToUrl($url);
 
             // already no more pages → stop

--- a/src/Github/GithubApi.php
+++ b/src/Github/GithubApi.php
@@ -131,9 +131,7 @@ final class GithubApi
 
     private function getMergedAtByPullRequest(int $id): ?string
     {
-        $url = sprintf(self::URL_PULL_REQUEST_BY_ID, $this->repositoryName, $id);
-        $response = $this->getResponseToUrl($url);
-        $json = $this->responseFormatter->formatToJson($response);
+        $json = $this->getSinglePullRequestJson($id);
 
         return $json['merged_at'] ?? null;
     }
@@ -179,5 +177,30 @@ final class GithubApi
         $message = $reason . PHP_EOL . 'Create a token at https://github.com/settings/tokens/new with only repository scope and use it as ENV variable: "GITHUB_TOKEN=... vendor/bin/changelog-linker ..." option.';
 
         return new GithubApiException($message, $throwable->getCode(), $throwable);
+    }
+
+    /**
+     * @param int $pullRequestId
+     * @param string $baseBranch
+     * @return bool
+     */
+    public function isPullRequestMergedToBaseBranch(int $pullRequestId, string $baseBranch): bool
+    {
+        $json = $this->getSinglePullRequestJson($pullRequestId);
+
+        return $json['base']['ref'] === $baseBranch;
+    }
+
+    /**
+     * @param int $pullRequestId
+     * @return array
+     */
+    private function getSinglePullRequestJson(int $pullRequestId): array
+    {
+        $url = sprintf(self::URL_PULL_REQUEST_BY_ID, $this->repositoryName, $pullRequestId);
+        $response = $this->getResponseToUrl($url);
+        $json = $this->responseFormatter->formatToJson($response);
+
+        return $json;
     }
 }


### PR DESCRIPTION
When a project has more supported releases, it is more than suitable to have the option to filter the pull requests by the base branch (see `base` parameter - https://developer.github.com/v3/pulls/#parameters).

Example: in Shopsys, we are releasing patches in `7.3` branch, and at the same time, we are working on `8.0.0` release in master. Imagine the situation when releasing `v7.3.x` patch version - When I use changelog linker `dump-merges`, at this moment, it dumps all the pull requests, including those that were merged to `master` branch - this is unwanted behavior and we need to remove them from the changelog manually which is annoying and boring job :slightly_smiling_face: 

This PR adds the option to filter the pull requests that were actually merged to `7.3` branch.

Note: We were discussing whether to name the parameter `$targetBranch` or `$baseBranch` - I stuck with `$baseBranch` as the parameter in Github API is called `base` as well :wink: 

TODO:

- [x] finding the highest pull request ID that was merged into a particular branch, not the highest ID globally
- [x] documenting the new option :slightly_smiling_face: 
- [x] creating the PR properly in monorepo